### PR TITLE
Mirgration to Navigator 2.0/ fix The getter 'isInitialRoute' isn't defined for the type 'RouteSettings'.

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -40,12 +40,6 @@ class _AppState extends State<App> {
         theme: ThemeData(fontFamily: 'Gotham'),
         title: 'Shop',
         onGenerateRoute: (settings) {
-          if (settings.isInitialRoute) {
-            return inPageRoute(
-                WelcomePage(),
-                RouteSettings(
-                    name: WelcomePage.routeName, isInitialRoute: true));
-          }
 
           if (_routes.containsKey(settings.name)) {
             final builder = _routes[settings.name];
@@ -55,6 +49,15 @@ class _AppState extends State<App> {
 
           return inPageRoute(NotFound());
         },
+        // Mirgration to Navigator 2.0
+        // merge request: https://github.com/flutter/flutter/pull/51435
+        // migration guide: https://flutter.dev/docs/release/breaking-changes/route-navigator-refactoring
+        onGenerateInitialRoutes: (initialRoute) {
+          return <Route>[
+            inPageRoute(
+                WelcomePage(), RouteSettings(name: WelcomePage.routeName))
+          ];
+        }
 
         // supportedLocales: [//TODO DEFINE SUPOORTED LANGSSSSS],
       ),


### PR DESCRIPTION
Mirgration to Navigator 2.0
Flutter official merge request: https://github.com/flutter/flutter/pull/51435
migration guide: https://flutter.dev/docs/release/breaking-changes/route-navigator-refactoring